### PR TITLE
BZ 63835: Add support for Keep-Alive header

### DIFF
--- a/java/org/apache/coyote/http11/Constants.java
+++ b/java/org/apache/coyote/http11/Constants.java
@@ -117,6 +117,7 @@ public final class Constants {
     public static final String CHUNKED = "chunked";
     public static final byte[] ACK_BYTES = ByteChunk.convertToBytes("HTTP/1.1 100 " + CRLF + CRLF);
     public static final String TRANSFERENCODING = "Transfer-Encoding";
+    public static final String KEEP_ALIVE = "Keep-Alive";
     public static final byte[] _200_BYTES = ByteChunk.convertToBytes("200");
     public static final byte[] _400_BYTES = ByteChunk.convertToBytes("400");
     public static final byte[] _404_BYTES = ByteChunk.convertToBytes("404");

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -907,8 +907,26 @@ public class Http11Processor extends AbstractProcessor {
                 headers.addValue(Constants.CONNECTION).setString(
                         Constants.CLOSE);
             }
-        } else if (!http11 && !getErrorState().isError()) {
-            headers.addValue(Constants.CONNECTION).setString(Constants.KEEPALIVE);
+        } else if (!getErrorState().isError()) {
+            if (!http11) {
+                headers.addValue(Constants.CONNECTION).setString(Constants.KEEPALIVE);
+            }
+
+            boolean connectionKeepAlivePresent =
+                isConnectionToken(request.getMimeHeaders(), Constants.KEEPALIVE);
+
+            if (connectionKeepAlivePresent) {
+                int keepAliveTimeout = protocol.getKeepAliveTimeout();
+
+                if (keepAliveTimeout > 0) {
+                    String value = "timeout=" + keepAliveTimeout / 1000L;
+                    headers.setValue(Constants.KEEP_ALIVE).setString(value);
+
+                    if (http11) {
+                        headers.addValue(Constants.CONNECTION).setString(Constants.KEEPALIVE);
+                    }
+                }
+            }
         }
 
         // Add server header

--- a/test/org/apache/catalina/startup/SimpleHttpClient.java
+++ b/test/org/apache/catalina/startup/SimpleHttpClient.java
@@ -56,6 +56,7 @@ public abstract class SimpleHttpClient {
     public static final String REDIRECT_302 = "HTTP/1.1 302 ";
     public static final String REDIRECT_303 = "HTTP/1.1 303 ";
     public static final String FAIL_400 = "HTTP/1.1 400 ";
+    public static final String FORBIDDEN_403 = "HTTP/1.1 403 ";
     public static final String FAIL_404 = "HTTP/1.1 404 ";
     public static final String FAIL_405 = "HTTP/1.1 405 ";
     public static final String TIMEOUT_408 = "HTTP/1.1 408 ";
@@ -442,6 +443,10 @@ public abstract class SimpleHttpClient {
 
     public boolean isResponse400() {
         return responseLineStartsWith(FAIL_400);
+    }
+
+    public boolean isResponse403() {
+        return responseLineStartsWith(FORBIDDEN_403);
     }
 
     public boolean isResponse404() {


### PR DESCRIPTION
This implementation slightly varies from HTTPd in way that it responds with
'Connection: keep-alive' if and only if additionally to the required request
header the keepAliveTimeout has to be greater than 0.

Also modified existing tests because HttpUrlConnection always sends
'Connection: keep-alive' where the tests are not aware of this thus fail.